### PR TITLE
chore: split API to stop/cancel/remove a single job / all jobs

### DIFF
--- a/src/schedule/Schedule.ts
+++ b/src/schedule/Schedule.ts
@@ -167,7 +167,7 @@ export class Schedule extends LogEmitter {
   public async removeJob(name: string): Promise<void> {
     this.cancelJob(name);
     this.logger.debug('remove', { name });
-    await getJobRepository().delete({ name }); // does this not fail if the job doesn't exist?
+    await getJobRepository().delete({ name });
   }
 
   /**

--- a/src/schedule/Schedule.ts
+++ b/src/schedule/Schedule.ts
@@ -154,7 +154,7 @@ export class Schedule extends LogEmitter {
    */
   public cancel(): void {
     this.stop();
-    this.logger.debug('cancel all jobs');
+    this.logger.debug('cancel all jobs', { count: Object.keys(this.jobs).length });
     this.jobs = {};
   }
 
@@ -176,8 +176,8 @@ export class Schedule extends LogEmitter {
   public async remove(): Promise<void> {
     const names = Object.keys(this.jobs);
     this.cancel();
-    this.logger.debug('remove all jobs');
-    await getJobRepository().deleteMany({ where: { name: { $in: names } } });
+    this.logger.debug('remove all jobs', { names: names.join(', ') });
+    await getJobRepository().deleteMany({ name: { $in: names } });
   }
 
   /**

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -41,7 +41,7 @@ export class JobScheduler {
     const delay = calculateDelay(interval, this.job.immediate, jobEntity);
     this.jobHandle = setIntervalWithDelay(this.executeConcurrently.bind(this), interval, delay);
 
-    this.logger.debug(`scheduled job to run at ${DateTime.now().plus({ millisecond: delay }).toISO()}`, {
+    this.logger.debug(`scheduled job to run at ${DateTime.now().plus({ milliseconds: delay }).toISO()}`, {
       name: this.job.name,
       interval,
       delay,

--- a/src/scheduler/calculateDelay.ts
+++ b/src/scheduler/calculateDelay.ts
@@ -2,10 +2,10 @@ import { JobEntity } from '../repository/JobEntity';
 import { DateTime } from 'luxon';
 import { max } from 'lodash';
 
-export function calculateDelay(interval: number, immediate: boolean, job: JobEntity): number {
-  const nextStart = calculateNextStart(interval, job);
+export function calculateDelay(millisecondsInterval: number, immediate: boolean, job: JobEntity): number {
+  const nextStart = calculateNextStart(millisecondsInterval, job);
   if (!nextStart) {
-    return immediate ? 0 : interval;
+    return immediate ? 0 : millisecondsInterval;
   }
 
   return max([nextStart - DateTime.now().toMillis(), 0]) ?? 0;
@@ -14,5 +14,5 @@ export function calculateDelay(interval: number, immediate: boolean, job: JobEnt
 function calculateNextStart(interval: number, job: JobEntity): number | undefined {
   const lastStarted = job.executionInfo?.lastStarted;
   const lastStartedDateTime = lastStarted ? DateTime.fromISO(lastStarted) : undefined;
-  return lastStartedDateTime?.plus(interval).toMillis();
+  return lastStartedDateTime?.plus({ milliseconds: interval }).toMillis();
 }

--- a/test/integration/schedule.spec.ts
+++ b/test/integration/schedule.spec.ts
@@ -128,30 +128,6 @@ describe('schedule', () => {
       await waitFor(() => expect(jobHandler.count).toBe(1), 600);
     });
 
-    it('stops all jobs', async () => {
-      await mongoSchedule.define(job);
-
-      await mongoSchedule.start();
-
-      await waitFor(() => expect(jobHandler.count).toBe(1));
-
-      mongoSchedule.stop();
-
-      await waitFor(() => expect(jobHandler.count).toBe(1), 1500);
-    });
-
-    it('cancels all jobs', async () => {
-      await mongoSchedule.define(job);
-
-      await mongoSchedule.start();
-
-      await waitFor(() => expect(jobHandler.count).toBe(1));
-
-      mongoSchedule.cancel();
-
-      await waitFor(() => expect(jobHandler.count).toBe(1), 1500);
-    });
-
     it('saves executionInfo in mongo', async () => {
       await mongoSchedule.define(job);
 
@@ -426,6 +402,63 @@ describe('schedule', () => {
         expect(jobHandler1.count).toBe(2);
         expect(jobHandler2.count).toBe(0);
       }, 3100);
+    });
+
+    it('stops all jobs', async () => {
+      await mongoSchedule.define(job1);
+      await mongoSchedule.define(job2);
+      await mongoSchedule.start();
+
+      await waitFor(() => {
+        expect(jobHandler1.count).toBe(1);
+        expect(jobHandler2.count).toBe(1);
+      });
+
+      mongoSchedule.stop();
+
+      await waitFor(() => {
+        expect(jobHandler1.count).toBe(1);
+        expect(jobHandler2.count).toBe(1);
+      }, 1500);
+    });
+
+    it('cancels all jobs', async () => {
+      await mongoSchedule.define(job1);
+      await mongoSchedule.define(job2);
+      await mongoSchedule.start();
+
+      await waitFor(() => {
+        expect(jobHandler1.count).toBe(1);
+        expect(jobHandler2.count).toBe(1);
+      });
+
+      mongoSchedule.cancel();
+
+      await waitFor(() => {
+        expect(jobHandler1.count).toBe(1);
+        expect(jobHandler2.count).toBe(1);
+      }, 1500);
+    });
+
+    it('removes all jobs', async () => {
+      await mongoSchedule.define(job1);
+      await mongoSchedule.define(job2);
+
+      await mongoSchedule.start();
+
+      await waitFor(() => {
+        expect(jobHandler1.count).toBe(1);
+        expect(jobHandler2.count).toBe(1);
+      });
+
+      await mongoSchedule.remove();
+
+      await sleep(1500);
+      expect(jobHandler1.count).toBe(1);
+      expect(jobHandler2.count).toBe(1);
+
+      const jobs = await jobRepository.find();
+      expect(jobs).toHaveLength(0);
     });
   });
 

--- a/test/integration/schedule.spec.ts
+++ b/test/integration/schedule.spec.ts
@@ -362,7 +362,7 @@ describe('schedule', () => {
         expect(jobHandler2.count).toBe(1);
       });
 
-      mongoSchedule.stop(job1.name);
+      mongoSchedule.stopJob(job1.name);
 
       await waitFor(() => {
         expect(jobHandler1.count).toBe(1);
@@ -381,7 +381,7 @@ describe('schedule', () => {
         expect(jobHandler2.count).toBe(1);
       });
 
-      await mongoSchedule.remove(job1.name);
+      await mongoSchedule.removeJob(job1.name);
 
       await waitFor(() => {
         expect(jobHandler1.count).toBe(1);
@@ -404,7 +404,7 @@ describe('schedule', () => {
         expect(jobHandler2.count).toBe(1);
       });
 
-      mongoSchedule.cancel(job1.name);
+      mongoSchedule.cancelJob(job1.name);
 
       await waitFor(() => {
         expect(jobHandler1.count).toBe(1);
@@ -416,7 +416,7 @@ describe('schedule', () => {
       await mongoSchedule.define(job1);
       await mongoSchedule.define(job2);
 
-      await mongoSchedule.start(job1.name);
+      await mongoSchedule.startJob(job1.name);
 
       await waitFor(() => {
         expect(jobHandler1.count).toBe(2);

--- a/test/integration/schedule.spec.ts
+++ b/test/integration/schedule.spec.ts
@@ -393,6 +393,10 @@ describe('schedule', () => {
       expect(jobs[0].name).toEqual(job2.name);
     });
 
+    it('does not fail when trying to remove a non existent job', async () => {
+      await expect(mongoSchedule.removeJob(job1.name)).resolves.not.toThrow();
+    });
+
     it('cancels one of two jobs', async () => {
       await mongoSchedule.define(job1);
       await mongoSchedule.define(job2);

--- a/test/schedule/MongoSchedule.spec.ts
+++ b/test/schedule/MongoSchedule.spec.ts
@@ -78,7 +78,7 @@ describe('MongoSchedule', () => {
     await mongoSchedule.define(jobToKeep);
     await mongoSchedule.define(job);
 
-    mongoSchedule.cancel(job.name);
+    mongoSchedule.cancelJob(job.name);
 
     const jobs = mongoSchedule.list();
     expect(jobs).toEqual([withDefaults(jobToKeep)]);
@@ -106,14 +106,14 @@ describe('MongoSchedule', () => {
     await mongoSchedule.define(notStartedJob);
     await mongoSchedule.define(job);
 
-    await mongoSchedule.start(job.name);
+    await mongoSchedule.startJob(job.name);
 
     expect(mongoSchedule.count()).toBe(2);
     expect(mongoSchedule.count(true)).toBe(1);
   });
 
   it('does nothing if a job is started that is not on the schedule', async () => {
-    await mongoSchedule.start('not defined');
+    await mongoSchedule.startJob('not defined');
 
     expect(mongoSchedule.count()).toBe(0);
     expect(mongoSchedule.count(true)).toBe(0);
@@ -137,7 +137,7 @@ describe('MongoSchedule', () => {
     const jobToKeep = { ...job, name };
     await mongoSchedule.define(jobToKeep);
 
-    await mongoSchedule.remove(job.name);
+    await mongoSchedule.removeJob(job.name);
 
     const jobs = mongoSchedule.list();
     expect(jobs).toEqual([withDefaults(jobToKeep)]);

--- a/test/schedule/MongoSchedule.spec.ts
+++ b/test/schedule/MongoSchedule.spec.ts
@@ -125,7 +125,7 @@ describe('MongoSchedule', () => {
 
     expect(mongoSchedule.list()).toHaveLength(0);
 
-    verify(jobRepository.deleteMany(deepEqual({ where: { name: { $in: [job.name] } } }))).once();
+    verify(jobRepository.deleteMany(deepEqual({ name: { $in: [job.name] } }))).once();
   });
 
   it('removes a job', async () => {


### PR DESCRIPTION
BREAKING CHANGE: scheduler API to stop/cancel/remove jobs does no longer accept an optional string to decide whether to apply changes to a single job or all of them. For single jobs use stop-/cancel-/removeJob.