### PR TITLE
chore: drop node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16]
 
     steps:
       - name: Checkout the repository
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16]
 
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Now assume the MongoSchedule is stopped at 12:02 and then immediately started ag
 
 ## Supported Node Versions
 
-momo-scheduler supports node 12, 14 and 16.
+momo-scheduler supports node 14 and 16.
 
 ## License
 


### PR DESCRIPTION
Node 12 blocks update to pino v8.
Since support for Node 12 officially ended already (cf. https://endoflife.date/nodejs), I suggest we simply drop it.

Signed-off-by: Ute Weiss <ute.weiss@tngtech.com>