### PR TITLE
Remove node 16 from tested versions and add node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [16, 18]
+        node: [18, 20]
 
     steps:
       - name: Checkout the repository
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [16, 18]
+        node: [18, 20]
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Setup node 16
+      - name: Setup node 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Run script
         run: |

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ of execution. They are also not restricted to a constant interval.
 
 ## Supported Node Versions
 
-momo-scheduler is currently tested on the node LTS versions 16 and 18.
+momo-scheduler is currently tested on the node LTS versions 18 and 20.
 
 ## License
 


### PR DESCRIPTION
Node 16 EOL was reached on Sep 11th.
Node 18 is still the LTS version, thus I kept it in those CI steps that we only do for one version.
Node 20 will become the new LTS version on Oct 24th, thus I already added it to the tested versions.

Resolves #521 