### PR TITLE
Disable the dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":gitSignOff"],
+  "extends": ["config:base", ":gitSignOff", ":disableDependencyDashboard"],
   "rangeStrategy": "pin",
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
This disables the dashboard so that we can close #49 without renovate re-opening it again.

Closes #49 