### PR TITLE
chore: remove renovate automerge config for lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,7 @@
   "extends": ["config:base", ":gitSignOff", ":disableDependencyDashboard", ":preserveSemverRanges"],
   "rangeStrategy": "pin",
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "automergeType": "branch"
+    "enabled": true
   },
   "packageRules": [
     {


### PR DESCRIPTION
PRs must be approved manually