### PR TITLE
chore!: drop node 20 support and add node 26 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24, 26]
 
     steps:
       - name: Checkout the repository
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24, 26]
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v7
 
-      - name: Setup node 22
+      - name: Setup node 24
         uses: actions/setup-node@v7
         with:
           node-version: 24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Next release
+
+- Breaking: Remove support for node 20
+
 ## v3.1.2 (2026-04-23)
 
 - Chore: Unpin dependency versions

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ restricted to a constant interval.
 
 ## Supported Node Versions
 
-momo-scheduler is currently tested on the node LTS versions 20, 22 and 24.
+momo-scheduler is currently tested on the node LTS versions 22, 24 and 26.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ restricted to a constant interval.
 
 ## Supported Node Versions
 
-momo-scheduler is currently tested on the node LTS versions 20, 22 and 24.
+momo-scheduler is currently tested on the node versions 22, 24 and 26.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "vitest": "3.2.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "mongodb": "5 || 6 || 7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "vitest-mock-extended": "4.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "mongodb": "5 || 6 || 7"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:integration": "vitest run test/**/*.integration.*"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:integration": "vitest run test/**/*.integration.*"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "cron": "^4.4.0",


### PR DESCRIPTION
Still uses v24 for checks like mongo compatibility as v26 only becomes active version in fall.

Resolves issue #1046